### PR TITLE
Solving #54 openai_api_key is missing when calling embeddings

### DIFF
--- a/tuto_chatbot_csv.py
+++ b/tuto_chatbot_csv.py
@@ -8,12 +8,15 @@ from langchain.chains import ConversationalRetrievalChain
 from langchain.document_loaders.csv_loader import CSVLoader
 from langchain.vectorstores import FAISS
 import tempfile
+import os
 
 
 user_api_key = st.sidebar.text_input(
     label="#### Your OpenAI API key 👇",
     placeholder="Paste your openAI API key, sk-",
     type="password")
+
+os.environ["OPENAI_API_KEY"] = user_api_key
 
 uploaded_file = st.sidebar.file_uploader("upload", type="csv")
 


### PR DESCRIPTION
Solving #54 openai_api_key is missing when calling embeddings. Set OPENAI_API_KEY environment variable from inputted value
